### PR TITLE
improve performance

### DIFF
--- a/deserialize.go
+++ b/deserialize.go
@@ -144,8 +144,7 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 	switch rv.Kind() {
 	case reflect.Int8:
 		b, o := d.read_s1(offset)
-		v := int8(b)
-		rv.Set(reflect.ValueOf(v))
+		rv.SetInt(int64(b))
 		// update
 		offset = o
 
@@ -153,8 +152,7 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 		// Int16 [short(2)]
 		b, o := d.read_s2(offset)
 		_v := binary.LittleEndian.Uint16(b)
-		v := int16(_v)
-		rv.Set(reflect.ValueOf(v))
+		rv.SetInt(int64(_v))
 		// update
 		offset = o
 
@@ -174,8 +172,8 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 			// Int32 [int(4)]
 			b, o := d.read_s4(offset)
 			_v := binary.LittleEndian.Uint32(b)
-			v := int32(int32(_v))
-			rv.Set(reflect.ValueOf(v))
+			// NOTE : double cast
+			rv.SetInt(int64(int32(_v)))
 			// update
 			offset = o
 		}
@@ -185,8 +183,7 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 		b, o := d.read_s4(offset)
 		_v := binary.LittleEndian.Uint32(b)
 		// NOTE : double cast
-		v := int(int32(_v))
-		rv.Set(reflect.ValueOf(v))
+		rv.SetInt(int64(int32(_v)))
 		// update
 		offset = o
 
@@ -205,9 +202,8 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 		} else {
 			// Int64 [long(8)]
 			b, o := d.read_s8(offset)
-			_v := binary.LittleEndian.Uint64(b)
-			v := int64(_v)
-			rv.SetInt(v)
+			v := binary.LittleEndian.Uint64(b)
+			rv.SetInt(int64(v))
 			// update
 			offset = o
 		}
@@ -215,8 +211,7 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 	case reflect.Uint8:
 		// byte in cSharp
 		_v, o := d.read_s1(offset)
-		v := uint8(_v)
-		rv.Set(reflect.ValueOf(v))
+		rv.SetUint(uint64(_v))
 		// update
 		offset = o
 
@@ -224,22 +219,21 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 		// Uint16 / Char
 		b, o := d.read_s2(offset)
 		v := binary.LittleEndian.Uint16(b)
-		rv.Set(reflect.ValueOf(v))
+		rv.SetUint(uint64(v))
 		// update
 		offset = o
 
 	case reflect.Uint32:
 		b, o := d.read_s4(offset)
 		v := binary.LittleEndian.Uint32(b)
-		rv.Set(reflect.ValueOf(v))
+		rv.SetUint(uint64(v))
 		// update
 		offset = o
 
 	case reflect.Uint:
 		b, o := d.read_s4(offset)
-		_v := binary.LittleEndian.Uint32(b)
-		v := uint(_v)
-		rv.Set(reflect.ValueOf(v))
+		v := binary.LittleEndian.Uint32(b)
+		rv.SetUint(uint64(v))
 		// update
 		offset = o
 
@@ -255,7 +249,7 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 		b, o := d.read_s4(offset)
 		_v := binary.LittleEndian.Uint32(b)
 		v := math.Float32frombits(_v)
-		rv.Set(reflect.ValueOf(v))
+		rv.SetFloat(float64(v))
 		// update
 		offset = o
 
@@ -264,7 +258,7 @@ func (d *deserializer) deserialize(rv reflect.Value, offset uint32) (uint32, err
 		b, o := d.read_s8(offset)
 		_v := binary.LittleEndian.Uint64(b)
 		v := math.Float64frombits(_v)
-		rv.Set(reflect.ValueOf(v))
+		rv.SetFloat(v)
 		// update
 		offset = o
 

--- a/serialize.go
+++ b/serialize.go
@@ -24,7 +24,8 @@ const (
 )
 
 type serializer struct {
-	data []byte
+	data   []byte
+	create []byte
 }
 
 func createSerializer() *serializer {
@@ -373,6 +374,57 @@ func (d *serializer) serialize(rv reflect.Value) ([]byte, error) {
 	return ret, nil
 }
 
+func Serialize2(holder interface{}) ([]byte, error) {
+	d := createSerializer()
+
+	t := reflect.ValueOf(holder)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+		if t.Kind() == reflect.Ptr {
+			t = t.Elem()
+		}
+	}
+
+	var err error
+	if t.Kind() == reflect.Struct && !isDateTime(t) && !isDateTimeOffset(t) {
+		startOffset := (2 + t.NumField()) * intByte4
+
+		hoge, _ := d.calcSize(t)
+		d.create = make([]byte, hoge+uint32(startOffset))
+
+		err = d.serializeStruct2(t, uint32(startOffset))
+	} else {
+		hoge, _ := d.calcSize(t)
+		d.create = make([]byte, hoge)
+		_, err = d.serialize2(t, 0)
+	}
+
+	return d.create, err
+}
+
+func (d *serializer) serializeStruct2(rv reflect.Value, offset uint32) error {
+	nf := rv.NumField()
+	index := 2 * intByte4
+	for i := 0; i < nf; i++ {
+		// todo : want to receive binary size
+		o, err := d.serialize2(rv.Field(i), offset)
+		if err != nil {
+			return err
+		}
+
+		d.create[index], d.create[index+1], d.create[index+2], d.create[index+3] = byte(offset), byte(offset>>8), byte(offset>>16), byte(offset>>24)
+		index += intByte4
+		offset = o
+	}
+	// size
+	si := len(d.create)
+	d.create[0], d.create[1], d.create[2], d.create[3] = byte(si), byte(si>>8), byte(si>>16), byte(si>>24)
+	// index max
+	im := nf - 1
+	d.create[4], d.create[5], d.create[6], d.create[7] = byte(im), byte(im>>8), byte(im>>16), byte(im>>24)
+	return nil
+}
+
 func (d *serializer) calcSize(rv reflect.Value) (uint32, error) {
 	ret := uint32(0)
 
@@ -474,4 +526,267 @@ func (d *serializer) calcSize(rv reflect.Value) (uint32, error) {
 	}
 
 	return ret, nil
+}
+
+func (d *serializer) serialize2(rv reflect.Value, offset uint32) (uint32, error) {
+
+	switch rv.Kind() {
+	case reflect.Int8:
+		v := rv.Int()
+		d.create[offset] = byte(v)
+		offset += uintByte1
+
+	case reflect.Int16:
+		v := rv.Int()
+		d.create[offset+0] = byte(v)
+		d.create[offset+1] = byte(v >> 8)
+		offset += uintByte2
+
+	case reflect.Int32:
+		if isChar(rv) {
+
+			// rune [ushort(2)]
+			enc := utf16.Encode([]rune{int32(rv.Int())})
+			v := enc[0]
+			d.create[offset+0] = byte(v)
+			d.create[offset+1] = byte(v >> 8)
+			offset += uintByte2
+		} else {
+			v := rv.Int()
+			d.create[offset+0] = byte(v)
+			d.create[offset+1] = byte(v >> 8)
+			d.create[offset+2] = byte(v >> 16)
+			d.create[offset+3] = byte(v >> 24)
+			offset += uintByte4
+		}
+
+	case reflect.Int:
+		v := rv.Int()
+		d.create[offset+0] = byte(v)
+		d.create[offset+1] = byte(v >> 8)
+		d.create[offset+2] = byte(v >> 16)
+		d.create[offset+3] = byte(v >> 24)
+		offset += uintByte4
+
+	case reflect.Int64:
+		if isDuration(rv) {
+			// seconds
+			ns := rv.MethodByName("Nanoseconds").Call([]reflect.Value{})[0]
+			nanoseconds := ns.Int()
+			sec, nsec := nanoseconds/(1000*1000), int32(nanoseconds%(1000*1000))
+			d.create[offset+0] = byte(sec)
+			d.create[offset+1] = byte(sec >> 8)
+			d.create[offset+2] = byte(sec >> 16)
+			d.create[offset+3] = byte(sec >> 24)
+			d.create[offset+4] = byte(sec >> 32)
+			d.create[offset+5] = byte(sec >> 40)
+			d.create[offset+6] = byte(sec >> 48)
+			d.create[offset+7] = byte(sec >> 56)
+
+			// nanos
+			o := uintByte8
+			d.create[offset+o+0] = byte(nsec)
+			d.create[offset+o+1] = byte(nsec >> 8)
+			d.create[offset+o+2] = byte(nsec >> 16)
+			d.create[offset+o+3] = byte(nsec >> 24)
+			offset += uintByte4 + uintByte8
+		} else {
+
+			v := rv.Int()
+			d.create[offset+0] = byte(v)
+			d.create[offset+1] = byte(v >> 8)
+			d.create[offset+2] = byte(v >> 16)
+			d.create[offset+3] = byte(v >> 24)
+			d.create[offset+4] = byte(v >> 32)
+			d.create[offset+5] = byte(v >> 40)
+			d.create[offset+6] = byte(v >> 48)
+			d.create[offset+7] = byte(v >> 56)
+			offset += uintByte8
+		}
+
+	case reflect.Uint8:
+		v := rv.Uint()
+		d.create[offset+0] = byte(v)
+		offset += uintByte1
+
+	case reflect.Uint16:
+		v := rv.Uint()
+		d.create[offset+0] = byte(v)
+		d.create[offset+1] = byte(v >> 8)
+		offset += uintByte2
+
+	case reflect.Uint32, reflect.Uint:
+		v := rv.Uint()
+		d.create[offset+0] = byte(v)
+		d.create[offset+1] = byte(v >> 8)
+		d.create[offset+2] = byte(v >> 16)
+		d.create[offset+3] = byte(v >> 24)
+		offset += uintByte4
+
+	case reflect.Uint64:
+		v := rv.Uint()
+		d.create[offset+0] = byte(v)
+		d.create[offset+1] = byte(v >> 8)
+		d.create[offset+2] = byte(v >> 16)
+		d.create[offset+3] = byte(v >> 24)
+		d.create[offset+4] = byte(v >> 32)
+		d.create[offset+5] = byte(v >> 40)
+		d.create[offset+6] = byte(v >> 48)
+		d.create[offset+7] = byte(v >> 56)
+		offset += uintByte8
+
+	case reflect.Float32:
+		v := math.Float32bits(float32(rv.Float()))
+		d.create[offset+0] = byte(v)
+		d.create[offset+1] = byte(v >> 8)
+		d.create[offset+2] = byte(v >> 16)
+		d.create[offset+3] = byte(v >> 24)
+		offset += uintByte4
+
+	case reflect.Float64:
+		v := math.Float64bits(rv.Float())
+		d.create[offset+0] = byte(v)
+		d.create[offset+1] = byte(v >> 8)
+		d.create[offset+2] = byte(v >> 16)
+		d.create[offset+3] = byte(v >> 24)
+		d.create[offset+4] = byte(v >> 32)
+		d.create[offset+5] = byte(v >> 40)
+		d.create[offset+6] = byte(v >> 48)
+		d.create[offset+7] = byte(v >> 56)
+		offset += uintByte8
+
+	case reflect.Bool:
+
+		if rv.Bool() {
+			d.create[offset+0] = 0x01
+		} else {
+			d.create[offset+0] = 0x00
+		}
+		offset += uintByte1
+
+	case reflect.String:
+		str := rv.String()
+		l := uint32(len(str))
+		d.create[offset+0] = byte(l)
+		d.create[offset+1] = byte(l >> 8)
+		d.create[offset+2] = byte(l >> 16)
+		d.create[offset+3] = byte(l >> 24)
+		offset += uintByte4
+
+		// NOTE : unsafe
+		strBytes := *(*[]byte)(unsafe.Pointer(&str))
+		for i := uint32(0); i < l; i++ {
+			d.create[offset+i] = strBytes[i]
+		}
+		offset += l
+
+	case reflect.Array, reflect.Slice:
+		l := rv.Len()
+		if l > 0 {
+			d.create[offset+0] = byte(l)
+			d.create[offset+1] = byte(l >> 8)
+			d.create[offset+2] = byte(l >> 16)
+			d.create[offset+3] = byte(l >> 24)
+
+			for i := 0; i < l; i++ {
+				o, err := d.serialize2(rv.Index(i), offset)
+				if err != nil {
+					return 0, err
+				}
+				offset += o
+			}
+		} else {
+			// only make length info
+			d.create[offset+0] = 0
+			d.create[offset+1] = 0
+			d.create[offset+2] = 0
+			d.create[offset+3] = 0
+			offset += uintByte4
+		}
+
+	case reflect.Struct:
+		if isDateTimeOffset(rv) {
+
+			// offset
+			rets := rv.MethodByName("Zone").Call([]reflect.Value{})
+			_, offSec := rets[0] /*name*/, rets[1].Int() /*offset*/
+			offMin := uint16(offSec / 60)
+
+			// seconds
+			rets = rv.MethodByName("Unix").Call([]reflect.Value{})
+			seconds := rets[0].Int() + offSec
+
+			// nanos
+			nanos := int32(rv.FieldByName("nsec").Int())
+
+			// seconds to byte
+			d.create[offset+0] = byte(seconds)
+			d.create[offset+1] = byte(seconds >> 8)
+			d.create[offset+2] = byte(seconds >> 16)
+			d.create[offset+3] = byte(seconds >> 24)
+			d.create[offset+4] = byte(seconds >> 32)
+			d.create[offset+5] = byte(seconds >> 40)
+			d.create[offset+6] = byte(seconds >> 48)
+			d.create[offset+7] = byte(seconds >> 56)
+
+			// nanos to byte
+			offset += uintByte8
+			d.create[offset+0] = byte(nanos)
+			d.create[offset+1] = byte(nanos >> 8)
+			d.create[offset+2] = byte(nanos >> 16)
+			d.create[offset+3] = byte(nanos >> 24)
+
+			// offset to byte
+			offset += uintByte4
+			d.create[offset+0] = byte(offMin)
+			d.create[offset+1] = byte(offMin >> 8)
+
+			offset += uintByte2
+		} else if isDateTime(rv) {
+			// seconds
+			unixTime := rv.MethodByName("Unix").Call([]reflect.Value{})
+			sec := unixTime[0].Int()
+			d.create[offset+0] = byte(sec)
+			d.create[offset+1] = byte(sec >> 8)
+			d.create[offset+2] = byte(sec >> 16)
+			d.create[offset+3] = byte(sec >> 24)
+			d.create[offset+4] = byte(sec >> 32)
+			d.create[offset+5] = byte(sec >> 40)
+			d.create[offset+6] = byte(sec >> 48)
+			d.create[offset+7] = byte(sec >> 56)
+
+			// nanos
+			nsec := int32(rv.FieldByName("nsec").Int())
+			offset += uintByte8
+			d.create[offset+0] = byte(nsec)
+			d.create[offset+1] = byte(nsec >> 8)
+			d.create[offset+2] = byte(nsec >> 16)
+			d.create[offset+3] = byte(nsec >> 24)
+
+			offset += uintByte4
+		} else {
+			for i := 0; i < rv.NumField(); i++ {
+				o, err := d.serialize2(rv.Field(i), offset)
+				if err != nil {
+					return 0, err
+				}
+				offset += o
+			}
+		}
+
+	case reflect.Ptr:
+		if rv.IsNil() {
+			return 0, errors.New(fmt.Sprint("pointer is null : ", rv.Type()))
+		}
+		o, err := d.serialize2(rv.Elem(), offset)
+		if err != nil {
+			return 0, err
+		}
+		offset += o
+
+	default:
+		return 0, errors.New(fmt.Sprint("this type is not supported : ", rv.Type()))
+	}
+
+	return offset, nil
 }

--- a/serialize.go
+++ b/serialize.go
@@ -43,366 +43,29 @@ func Serialize(holder interface{}) ([]byte, error) {
 		}
 	}
 
-	var b []byte
 	var err error
 	if t.Kind() == reflect.Struct && !isDateTime(t) && !isDateTimeOffset(t) {
 		startOffset := (2 + t.NumField()) * intByte4
 
-		// NOTE : memory allocation is not just size.
-		b = make([]byte, startOffset, int(t.Type().Size())+startOffset)
-		err = d.serializeStruct(t, &b, startOffset)
+		dataPartSize, _ := d.calcSize(t)
+		size := uint32(startOffset) + dataPartSize
+		d.create = make([]byte, size)
+
+		err = d.serializeStruct(t, uint32(startOffset), size)
 	} else {
-		b, err = d.serialize(t)
-	}
-
-	return b, err
-}
-
-func (d *serializer) serializeStruct(rv reflect.Value, b *[]byte, offset int) error {
-	nf := rv.NumField()
-	index := 2 * intByte4
-	for i := 0; i < nf; i++ {
-		// todo : want to receive binary size
-		ab, err := d.serialize(rv.Field(i))
-		if err != nil {
-			return err
-		}
-		*b = append(*b, ab...)
-
-		(*b)[index], (*b)[index+1], (*b)[index+2], (*b)[index+3] = byte(offset), byte(offset>>8), byte(offset>>16), byte(offset>>24)
-		index += intByte4
-		offset += len(ab)
-	}
-	// size
-	si := len(*b)
-	(*b)[0], (*b)[1], (*b)[2], (*b)[3] = byte(si), byte(si>>8), byte(si>>16), byte(si>>24)
-	// index max
-	im := nf - 1
-	(*b)[4], (*b)[5], (*b)[6], (*b)[7] = byte(im), byte(im>>8), byte(im>>16), byte(im>>24)
-	return nil
-}
-
-func (d *serializer) serialize(rv reflect.Value) ([]byte, error) {
-	var ret []byte
-
-	switch rv.Kind() {
-	case reflect.Int8:
-		b := make([]byte, uintByte1)
-		v := rv.Int()
-		b[0] = byte(v)
-		ret = b
-
-	case reflect.Int16:
-		b := make([]byte, uintByte2)
-		v := rv.Int()
-		b[0] = byte(v)
-		b[1] = byte(v >> 8)
-		ret = b
-
-	case reflect.Int32:
-		if isChar(rv) {
-
-			// rune [ushort(2)]
-			enc := utf16.Encode([]rune{int32(rv.Int())})
-
-			b := make([]byte, uintByte2)
-			v := enc[0]
-			b[0] = byte(v)
-			b[1] = byte(v >> 8)
-			ret = b
-		} else {
-			b := make([]byte, uintByte4)
-			v := rv.Int()
-			b[0] = byte(v)
-			b[1] = byte(v >> 8)
-			b[2] = byte(v >> 16)
-			b[3] = byte(v >> 24)
-			ret = b
-
-		}
-
-	case reflect.Int:
-		b := make([]byte, uintByte4)
-		v := rv.Int()
-		b[0] = byte(v)
-		b[1] = byte(v >> 8)
-		b[2] = byte(v >> 16)
-		b[3] = byte(v >> 24)
-		ret = b
-
-	case reflect.Int64:
-		if isDuration(rv) {
-			b := make([]byte, uintByte4+uintByte8, uintByte4+uintByte8)
-			// seconds
-			ns := rv.MethodByName("Nanoseconds").Call([]reflect.Value{})[0]
-			nanoseconds := ns.Int()
-			sec, nsec := nanoseconds/(1000*1000), int32(nanoseconds%(1000*1000))
-			b[0] = byte(sec)
-			b[1] = byte(sec >> 8)
-			b[2] = byte(sec >> 16)
-			b[3] = byte(sec >> 24)
-			b[4] = byte(sec >> 32)
-			b[5] = byte(sec >> 40)
-			b[6] = byte(sec >> 48)
-			b[7] = byte(sec >> 56)
-
-			// nanos
-			o := uintByte8
-			b[o+0] = byte(nsec)
-			b[o+1] = byte(nsec >> 8)
-			b[o+2] = byte(nsec >> 16)
-			b[o+3] = byte(nsec >> 24)
-			ret = b
-		} else {
-
-			b := make([]byte, uintByte8)
-			v := rv.Int()
-			b[0] = byte(v)
-			b[1] = byte(v >> 8)
-			b[2] = byte(v >> 16)
-			b[3] = byte(v >> 24)
-			b[4] = byte(v >> 32)
-			b[5] = byte(v >> 40)
-			b[6] = byte(v >> 48)
-			b[7] = byte(v >> 56)
-			ret = b
-		}
-
-	case reflect.Uint8:
-		b := make([]byte, uintByte1)
-		v := rv.Uint()
-		b[0] = byte(v)
-		ret = b
-
-	case reflect.Uint16:
-		b := make([]byte, uintByte2)
-		v := rv.Uint()
-		b[0] = byte(v)
-		b[1] = byte(v >> 8)
-		ret = b
-
-	case reflect.Uint32, reflect.Uint:
-		b := make([]byte, uintByte4)
-		v := rv.Uint()
-		b[0] = byte(v)
-		b[1] = byte(v >> 8)
-		b[2] = byte(v >> 16)
-		b[3] = byte(v >> 24)
-		ret = b
-
-	case reflect.Uint64:
-		b := make([]byte, uintByte8)
-		v := rv.Uint()
-		b[0] = byte(v)
-		b[1] = byte(v >> 8)
-		b[2] = byte(v >> 16)
-		b[3] = byte(v >> 24)
-		b[4] = byte(v >> 32)
-		b[5] = byte(v >> 40)
-		b[6] = byte(v >> 48)
-		b[7] = byte(v >> 56)
-		ret = b
-
-	case reflect.Float32:
-		b := make([]byte, uintByte4)
-
-		v := math.Float32bits(float32(rv.Float()))
-		b[0] = byte(v)
-		b[1] = byte(v >> 8)
-		b[2] = byte(v >> 16)
-		b[3] = byte(v >> 24)
-		ret = b
-
-	case reflect.Float64:
-		b := make([]byte, uintByte8)
-
-		v := math.Float64bits(rv.Float())
-		b[0] = byte(v)
-		b[1] = byte(v >> 8)
-		b[2] = byte(v >> 16)
-		b[3] = byte(v >> 24)
-		b[4] = byte(v >> 32)
-		b[5] = byte(v >> 40)
-		b[6] = byte(v >> 48)
-		b[7] = byte(v >> 56)
-		ret = b
-
-	case reflect.Bool:
-		b := make([]byte, uintByte1)
-
-		if rv.Bool() {
-			b[0] = 0x01
-		} else {
-			b[0] = 0x00
-		}
-		ret = b
-
-	case reflect.String:
-		str := rv.String()
-		l := uint32(len(str))
-		b := make([]byte, 0, l+uintByte4)
-		b = append(b, byte(l), byte(l>>8), byte(l>>16), byte(l>>24))
-
-		// NOTE : unsafe
-		strBytes := *(*[]byte)(unsafe.Pointer(&str))
-		b = append(b, strBytes...)
-		ret = b
-
-	case reflect.Array, reflect.Slice:
-		l := rv.Len()
-		if l > 0 {
-			// first : know element size
-			fb, err := d.serialize(rv.Index(0))
-			if err != nil {
-				return []byte(""), err
-			}
-
-			// second : make byte array
-			size := uint32(l*len(fb)) + uintByte4
-			b := make([]byte, 0, size)
-
-			// third : append data
-			b = append(b, byte(l), byte(l>>8), byte(l>>16), byte(l>>24))
-			b = append(b, fb...)
-
-			for i := 1; i < l; i++ {
-				ab, err := d.serialize(rv.Index(i))
-				if err != nil {
-					return []byte(""), err
-				}
-				b = append(b, ab...)
-			}
-			ret = b
-		} else {
-			// only make length info
-			b := make([]byte, uintByte4)
-			ret = b
-		}
-
-	case reflect.Struct:
-		if isDateTimeOffset(rv) {
-
-			b := make([]byte, uintByte4+uintByte8+uintByte2, uintByte4+uintByte8+uintByte2)
-
-			// offset
-			rets := rv.MethodByName("Zone").Call([]reflect.Value{})
-			_, offSec := rets[0] /*name*/, rets[1].Int() /*offset*/
-			offMin := uint16(offSec / 60)
-
-			// seconds
-			rets = rv.MethodByName("Unix").Call([]reflect.Value{})
-			seconds := rets[0].Int() + offSec
-
-			// nanos
-			nanos := int32(rv.FieldByName("nsec").Int())
-
-			// seconds to byte
-			b[0] = byte(seconds)
-			b[1] = byte(seconds >> 8)
-			b[2] = byte(seconds >> 16)
-			b[3] = byte(seconds >> 24)
-			b[4] = byte(seconds >> 32)
-			b[5] = byte(seconds >> 40)
-			b[6] = byte(seconds >> 48)
-			b[7] = byte(seconds >> 56)
-
-			// nanos to byte
-			o := uintByte8
-			b[o+0] = byte(nanos)
-			b[o+1] = byte(nanos >> 8)
-			b[o+2] = byte(nanos >> 16)
-			b[o+3] = byte(nanos >> 24)
-
-			// offset to byte
-			o += uintByte4
-			b[o+0] = byte(offMin)
-			b[o+1] = byte(offMin >> 8)
-
-			ret = b
-		} else if isDateTime(rv) {
-			b := make([]byte, uintByte4+uintByte8, uintByte4+uintByte8)
-			// seconds
-			unixTime := rv.MethodByName("Unix").Call([]reflect.Value{})
-			sec := unixTime[0].Int()
-			b[0] = byte(sec)
-			b[1] = byte(sec >> 8)
-			b[2] = byte(sec >> 16)
-			b[3] = byte(sec >> 24)
-			b[4] = byte(sec >> 32)
-			b[5] = byte(sec >> 40)
-			b[6] = byte(sec >> 48)
-			b[7] = byte(sec >> 56)
-
-			// nanos
-			nsec := int32(rv.FieldByName("nsec").Int())
-			o := uintByte8
-			b[o+0] = byte(nsec)
-			b[o+1] = byte(nsec >> 8)
-			b[o+2] = byte(nsec >> 16)
-			b[o+3] = byte(nsec >> 24)
-			ret = b
-		} else {
-			b := make([]byte, 0, rv.Type().Size())
-			for i := 0; i < rv.NumField(); i++ {
-				ab, err := d.serialize(rv.Field(i))
-				if err != nil {
-					return []byte(""), err
-				}
-				b = append(b, ab...)
-			}
-			ret = b
-		}
-
-	case reflect.Ptr:
-		if rv.IsNil() {
-			return []byte(""), errors.New(fmt.Sprint("pointer is null : ", rv.Type()))
-		}
-		b, err := d.serialize(rv.Elem())
-		if err != nil {
-			return []byte(""), err
-		}
-		ret = b
-
-	default:
-		return []byte(""), errors.New(fmt.Sprint("this type is not supported : ", rv.Type()))
-	}
-
-	return ret, nil
-}
-
-func Serialize2(holder interface{}) ([]byte, error) {
-	d := createSerializer()
-
-	t := reflect.ValueOf(holder)
-	if t.Kind() == reflect.Ptr {
-		t = t.Elem()
-		if t.Kind() == reflect.Ptr {
-			t = t.Elem()
-		}
-	}
-
-	var err error
-	if t.Kind() == reflect.Struct && !isDateTime(t) && !isDateTimeOffset(t) {
-		startOffset := (2 + t.NumField()) * intByte4
-
-		hoge, _ := d.calcSize(t)
-		d.create = make([]byte, hoge+uint32(startOffset))
-
-		err = d.serializeStruct2(t, uint32(startOffset))
-	} else {
-		hoge, _ := d.calcSize(t)
-		d.create = make([]byte, hoge)
-		_, err = d.serialize2(t, 0)
+		size, _ := d.calcSize(t)
+		d.create = make([]byte, size)
+		_, err = d.serialize(t, 0)
 	}
 
 	return d.create, err
 }
 
-func (d *serializer) serializeStruct2(rv reflect.Value, offset uint32) error {
+func (d *serializer) serializeStruct(rv reflect.Value, offset uint32, size uint32) error {
 	nf := rv.NumField()
 	index := 2 * intByte4
 	for i := 0; i < nf; i++ {
-		s, err := d.serialize2(rv.Field(i), offset)
+		s, err := d.serialize(rv.Field(i), offset)
 		if err != nil {
 			return err
 		}
@@ -412,11 +75,10 @@ func (d *serializer) serializeStruct2(rv reflect.Value, offset uint32) error {
 		offset += s
 	}
 	// size
-	si := len(d.create)
-	d.create[0], d.create[1], d.create[2], d.create[3] = byte(si), byte(si>>8), byte(si>>16), byte(si>>24)
-	// index max
-	im := nf - 1
-	d.create[4], d.create[5], d.create[6], d.create[7] = byte(im), byte(im>>8), byte(im>>16), byte(im>>24)
+	d.create[0], d.create[1], d.create[2], d.create[3] = byte(size), byte(size>>8), byte(size>>16), byte(size>>24)
+	// last index
+	li := nf - 1
+	d.create[4], d.create[5], d.create[6], d.create[7] = byte(li), byte(li>>8), byte(li>>16), byte(li>>24)
 	return nil
 }
 
@@ -523,7 +185,7 @@ func (d *serializer) calcSize(rv reflect.Value) (uint32, error) {
 	return ret, nil
 }
 
-func (d *serializer) serialize2(rv reflect.Value, offset uint32) (uint32, error) {
+func (d *serializer) serialize(rv reflect.Value, offset uint32) (uint32, error) {
 	size := uint32(0)
 
 	switch rv.Kind() {
@@ -689,7 +351,7 @@ func (d *serializer) serialize2(rv reflect.Value, offset uint32) (uint32, error)
 			offset += uintByte4
 
 			for i := 0; i < l; i++ {
-				s, err := d.serialize2(rv.Index(i), offset)
+				s, err := d.serialize(rv.Index(i), offset)
 				if err != nil {
 					return 0, err
 				}
@@ -768,7 +430,7 @@ func (d *serializer) serialize2(rv reflect.Value, offset uint32) (uint32, error)
 			size += uintByte4
 		} else {
 			for i := 0; i < rv.NumField(); i++ {
-				s, err := d.serialize2(rv.Field(i), offset)
+				s, err := d.serialize(rv.Field(i), offset)
 				if err != nil {
 					return 0, err
 				}
@@ -781,7 +443,7 @@ func (d *serializer) serialize2(rv reflect.Value, offset uint32) (uint32, error)
 		if rv.IsNil() {
 			return 0, errors.New(fmt.Sprint("pointer is null : ", rv.Type()))
 		}
-		s, err := d.serialize2(rv.Elem(), offset)
+		s, err := d.serialize(rv.Elem(), offset)
 		if err != nil {
 			return 0, err
 		}


### PR DESCRIPTION
improve serialize / deserialize performance.

#### old
```text
BenchmarkPackZeroformatter-8         1000000          1222 ns/op         800 B/op         23 allocs/op
BenchmarkPackMsgpack-8                500000          2912 ns/op         432 B/op          5 allocs/op
BenchmarkUnpackZeroformatter-8       1000000          2297 ns/op         744 B/op         32 allocs/op
BenchmarkUnpackMsgpack-8              300000          4252 ns/op         664 B/op         21 allocs/op
```

#### new
```text
BenchmarkPackZeroformatter-8         2000000           975 ns/op         272 B/op          2 allocs/op
BenchmarkPackMsgpack-8                500000          2959 ns/op         432 B/op          5 allocs/op
BenchmarkUnpackZeroformatter-8       1000000          1715 ns/op         632 B/op         18 allocs/op
BenchmarkUnpackMsgpack-8              300000          4457 ns/op         664 B/op         21 allocs/op
```